### PR TITLE
Patch to fix some minor bugs and broaden functionality 

### DIFF
--- a/WebSocketClient.cpp
+++ b/WebSocketClient.cpp
@@ -76,6 +76,9 @@ bool WebSocketClient::analyzeRequest() {
     socket_client->print(F("Sec-WebSocket-Key: "));
     socket_client->print(key);
     socket_client->print(CRLF);
+    socket_client->print(F("Sec-WebSocket-Protocol: "));
+    socket_client->print(protocol);
+    socket_client->print(CRLF);
     socket_client->print(F("Sec-WebSocket-Version: 13\r\n"));
     socket_client->print(CRLF);
 
@@ -131,7 +134,7 @@ bool WebSocketClient::analyzeRequest() {
 }
 
 
-String WebSocketClient::handleStream() {
+bool WebSocketClient::handleStream(String& data, uint8_t *opcode) {
     uint8_t msgtype;
     uint8_t bite;
     unsigned int length;
@@ -140,93 +143,96 @@ String WebSocketClient::handleStream() {
     unsigned int i;
     bool hasMask = false;
 
-    // String to hold bytes sent by server to client
-    String socketString;
+    if (!socket_client->connected() || !socket_client->available())
+    {
+        return false;
+    }      
 
-    if (socket_client->connected() && socket_client->available()) {
-
-        msgtype = timedRead();
-        if (!socket_client->connected()) {
-            return socketString;
-        }
-
-        length = timedRead();
-
-        if (length > 127) {
-            hasMask = true;
-            length = length & 127;
-        }
-
-
-        if (!socket_client->connected()) {
-            return socketString;
-        }
-
-        index = 6;
-
-        if (length == 126) {
-            length = timedRead() << 8;
-            if (!socket_client->connected()) {
-                return socketString;
-            }
-            
-            length |= timedRead();
-            if (!socket_client->connected()) {
-                return socketString;
-            }   
-
-        } else if (length == 127) {
-#ifdef DEBUGGING
-            Serial.println(F("No support for over 16 bit sized messages"));
-#endif
-            while(1) {
-                // halt, can't handle this case
-            }
-        }
-
-        if (hasMask) {
-            // get the mask
-            mask[0] = timedRead();
-            if (!socket_client->connected()) {
-                return socketString;
-            }
-
-            mask[1] = timedRead();
-            if (!socket_client->connected()) {
-
-                return socketString;
-            }
-
-            mask[2] = timedRead();
-            if (!socket_client->connected()) {
-                return socketString;
-            }
-
-            mask[3] = timedRead();
-            if (!socket_client->connected()) {
-                return socketString;
-            }
-        }
-
-        if (hasMask) {
-            for (i=0; i<length; ++i) {
-                socketString += (char) (timedRead() ^ mask[i % 4]);
-                if (!socket_client->connected()) {
-                    return socketString;
-                }
-            }
-        } else {
-            for (i=0; i<length; ++i) {
-                socketString += (char) timedRead();
-                if (!socket_client->connected()) {
-                    return socketString;
-                }
-            }            
-        }
-
+    msgtype = timedRead();
+    if (!socket_client->connected()) {
+        return false;
     }
 
-    return socketString;
+    length = timedRead();
+
+    if (length & WS_MASK) {
+        hasMask = true;
+        length = length & ~WS_MASK;
+    }
+
+
+    if (!socket_client->connected()) {
+        return false;
+    }
+
+    index = 6;
+
+    if (length == WS_SIZE16) {
+        length = timedRead() << 8;
+        if (!socket_client->connected()) {
+            return false;
+        }
+            
+        length |= timedRead();
+        if (!socket_client->connected()) {
+            return false;
+        }   
+
+    } else if (length == WS_SIZE64) {
+#ifdef DEBUGGING
+        Serial.println(F("No support for over 16 bit sized messages"));
+#endif
+        return false;
+    }
+
+    if (hasMask) {
+        // get the mask
+        mask[0] = timedRead();
+        if (!socket_client->connected()) {
+            return false;
+        }
+
+        mask[1] = timedRead();
+        if (!socket_client->connected()) {
+
+            return false;
+        }
+
+        mask[2] = timedRead();
+        if (!socket_client->connected()) {
+            return false;
+        }
+
+        mask[3] = timedRead();
+        if (!socket_client->connected()) {
+            return false;
+        }
+    }
+        
+    data = "";
+        
+    if (opcode != NULL)
+    {
+      *opcode = msgtype & ~WS_FIN;
+    }
+                
+    if (hasMask) {
+        for (i=0; i<length; ++i) {
+            data += (char) (timedRead() ^ mask[i % 4]);
+            if (!socket_client->connected()) {
+                return false;
+            }
+        }
+    } else {
+        for (i=0; i<length; ++i) {
+            data += (char) timedRead();
+            if (!socket_client->connected()) {
+                return false;
+            }
+        }            
+    }
+    
+    return true;
 }
 
 void WebSocketClient::disconnectStream() {
@@ -242,31 +248,27 @@ void WebSocketClient::disconnectStream() {
     socket_client->stop();
 }
 
-String WebSocketClient::getData() {
-    String data;
+bool WebSocketClient::getData(String& data, uint8_t *opcode) {
+    return handleStream(data, opcode);
+}    
 
-    data = handleStream();
-
-    return data;
-}
-
-void WebSocketClient::sendData(const char *str) {
+void WebSocketClient::sendData(const char *str, uint8_t opcode) {
 #ifdef DEBUGGING
     Serial.print(F("Sending data: "));
     Serial.println(str);
 #endif
     if (socket_client->connected()) {
-        sendEncodedData(str);       
+        sendEncodedData(str, opcode);       
     }
 }
 
-void WebSocketClient::sendData(String str) {
+void WebSocketClient::sendData(String str, uint8_t opcode) {
 #ifdef DEBUGGING
     Serial.print(F("Sending data: "));
     Serial.println(str);
 #endif
     if (socket_client->connected()) {
-        sendEncodedData(str);
+        sendEncodedData(str, opcode);
     }
 }
 
@@ -278,31 +280,42 @@ int WebSocketClient::timedRead() {
   return socket_client->read();
 }
 
-void WebSocketClient::sendEncodedData(char *str) {
+void WebSocketClient::sendEncodedData(char *str, uint8_t opcode) {
+    uint8_t mask[4];
     int size = strlen(str);
 
-    // string type
-    socket_client->write(0x81);
+    // Opcode; final fragment
+    socket_client->write(opcode | WS_FIN);
 
     // NOTE: no support for > 16-bit sized messages
     if (size > 125) {
-        socket_client->write(126);
+        socket_client->write(WS_SIZE16 | WS_MASK);
         socket_client->write((uint8_t) (size >> 8));
-        socket_client->write((uint8_t) (size && 0xFF));
+        socket_client->write((uint8_t) (size & 0xFF));
     } else {
-        socket_client->write((uint8_t) size);
+        socket_client->write((uint8_t) size | WS_MASK);
     }
 
+    mask[0] = random(0, 256);
+    mask[1] = random(0, 256);
+    mask[2] = random(0, 256);
+    mask[3] = random(0, 256);
+    
+    socket_client->write(mask[0]);
+    socket_client->write(mask[1]);
+    socket_client->write(mask[2]);
+    socket_client->write(mask[3]);
+     
     for (int i=0; i<size; ++i) {
-        socket_client->write(str[i]);
+        socket_client->write(str[i] ^ mask[i % 4]);
     }
 }
 
-void WebSocketClient::sendEncodedData(String str) {
+void WebSocketClient::sendEncodedData(String str, uint8_t opcode) {
     int size = str.length() + 1;
     char cstr[size];
 
     str.toCharArray(cstr, size);
 
-    sendEncodedData(cstr);
+    sendEncodedData(cstr, opcode);
 }

--- a/WebSocketClient.h
+++ b/WebSocketClient.h
@@ -69,6 +69,20 @@ http://tools.ietf.org/html/draft-hixie-thewebsocketprotocol-75
 
 #define SIZE(array) (sizeof(array) / sizeof(*array))
 
+// WebSocket protocol constants
+// First byte
+#define WS_FIN            0x80
+#define WS_OPCODE_TEXT    0x01
+#define WS_OPCODE_BINARY  0x02
+#define WS_OPCODE_CLOSE   0x08
+#define WS_OPCODE_PING    0x09
+#define WS_OPCODE_PONG    0x0a
+// Second byte
+#define WS_MASK           0x80
+#define WS_SIZE16         126
+#define WS_SIZE64         127
+
+  
 class WebSocketClient {
 public:
 
@@ -77,14 +91,15 @@ public:
     bool handshake(Client &client);
     
     // Get data off of the stream
-    String getData();
+    bool getData(String& data, uint8_t *opcode = NULL);
 
     // Write data to the stream
-    void sendData(const char *str);
-    void sendData(String str);
+    void sendData(const char *str, uint8_t opcode = WS_OPCODE_TEXT);
+    void sendData(String str, uint8_t opcode = WS_OPCODE_TEXT);
 
     char *path;
     char *host;
+    char *protocol;
 
 private:
     Client *socket_client;
@@ -96,15 +111,15 @@ private:
     // websocket connection.
     bool analyzeRequest();
 
-    String handleStream();    
+    bool handleStream(String& data, uint8_t *opcode);    
     
     // Disconnect user gracefully.
     void disconnectStream();
     
     int timedRead();
 
-    void sendEncodedData(char *str);
-    void sendEncodedData(String str);
+    void sendEncodedData(char *str, uint8_t opcode);
+    void sendEncodedData(String str, uint8_t opcode);
 };
 
 


### PR DESCRIPTION
This is a patch which addresses the following:
- Fixed payload length bug; Added protocol header, ping/pong, data masking.
- 16-bit payload lengths were invalid due to a typo, && should be &.
- Added Sec-WebSocket-Protocol header.
- getData and sendData methods now take an opcode value. This is used to implement ping/pong.
- sendEncodedData now applies a mask to the data.
- WebSocket constants have been #defined.
